### PR TITLE
De-duplicate images in final discovery output

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -5,13 +5,42 @@ type Manifest struct {
 	DiscoveredImages []DiscoveredImage
 }
 
-// DiscoveredImage is a container image that' been discovered based on the
-// workload watchers.
+// DiscoveredImage is a container image which was discovered in one or more workloads.
 type DiscoveredImage struct {
-	// PodName is the pod.metadata.name value where the image was discovered.
-	PodName string
-	// ContainerName represents the container in the pod that had the image.
-	ContainerName string
 	// Image is a fully qualified container image name and tag or digest.
 	Image string
+
+	// Containers is a list of DiscoveredContainer objects which are using
+	// the discovered image.
+	Containers []DiscoveredContainer
+}
+
+// DiscoveredContainer is a container which was observed during the discovery process.
+type DiscoveredContainer struct {
+	// Name is the name of a container in a pod.
+	Name string
+
+	// Type is the ContainerType of the container in its pod.
+	Type ContainerType
+
+	// Pod is the DiscoveredPod which this container is a part of.
+	Pod DiscoveredPod
+}
+
+// ContainerType is the type of a container in a pod.
+type ContainerType = string
+
+const (
+	ContainerTypeStandard  ContainerType = "Container"
+	ContainerTypeInit      ContainerType = "InitContainer"
+	ContainerTypeEphemeral ContainerType = "EphemeralContainer"
+)
+
+// DiscoveredPod is a pod that contains a discovered image.
+type DiscoveredPod struct {
+	// Name is the pod.metadata.name value where the image was discovered.
+	Name string
+
+	// Namespace is the pod.metadata.namespace value of the pod.
+	Namespace string
 }


### PR DESCRIPTION
This change modifies DiscoveredImage to store the name/type of one or more containers which use the image, and it also adds a new Insert method on Manifest, which acts similarly to the built-in append except duplicate entries are merged into the existing DiscoveredImage instance in the list.

---

A corresponding change is still needed on the `productctl` side to ingest the new schema.