### PR TITLE
Implement OS signal awareness for the CLI

### DIFF
--- a/internal/discover/processor_test.go
+++ b/internal/discover/processor_test.go
@@ -394,6 +394,11 @@ func TestManifestJSONProcessor(t *testing.T) {
 		compact  bool
 		expected []byte
 	}{
+		"no pods": {
+			ctx:      context.TODO(),
+			input:    []corev1.Pod{},
+			expected: []byte{},
+		},
 		"initContainer only": {
 			ctx: context.TODO(),
 			input: []corev1.Pod{
@@ -461,7 +466,7 @@ func TestManifestJSONProcessor(t *testing.T) {
 			actual, err := io.ReadAll(buffer)
 
 			if testFnErr != nil {
-				t.Fatalf("processor function threw an error unexpectedly: %q", err)
+				t.Fatalf("processor function threw an error unexpectedly: %q", testFnErr)
 			}
 
 			if err != nil {


### PR DESCRIPTION
This change adds a signal handler for SIGINT and SIGTERM to cancel the context used by the processing function. The processing function already prints the manifest that has been collected so far once it exits the watch loop.

`discover.WatchForWorkloads` already waits for goroutines to exit before returning, so the main goroutine should stay alive until the processing goroutine has printed and exited.

This PR also includes a few miscellaneous test fixes/test cases from along the way.