### PR TITLE
Add -trimpath flag and -s -w ldflags on builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ run:
 .PHONY: bin build
 bin build:
 	CGO_ENABLED=0 go build -o $(BIN_NAME) \
+		-trimpath \
 		-ldflags "\
+			-s -w \
 			-X github.com/opdev/discover-workload/internal/version.Commit=$(COMMIT) \
 			-X github.com/opdev/discover-workload/internal/version.Version=$(BIN_VERSION)" \
 		internal/cmd/main/discover-workload.go


### PR DESCRIPTION
| Platform | Before | After |
| --- | --- | --- |
| linux/amd64 | 53 MiB | 36 MiB |
| linux/arm64 | 51 MiB | 35 MiB |
| linux/s390x | 56 MiB | 40 MiB |
| linux/ppc64le | 52 MiB | 36 MiB |
| darwin/amd64 | 53 MiB | 37 MiB |
| darwin/arm64 | 51 MiB | 36 MiB |

Similar change to https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/1281.